### PR TITLE
AV-628: improved analytics filters to take away most current bot trafic

### DIFF
--- a/ckanext/googleanalytics/commands.py
+++ b/ckanext/googleanalytics/commands.py
@@ -160,6 +160,18 @@ class GACommand(p.toolkit.CkanCommand):
         if len(args) == 3:
             given_start_date = datetime.datetime.strptime(args[2], '%Y-%m-%d').date()
 
+        botFilters = [
+            'ga:browser!@StatusCake',
+            'ga:browser!@Python',
+            'ga:sessionDurationBucket!=0',
+            'ga:sessionDurationBucket!=1',
+            'ga:sessionDurationBucket!=2',
+            'ga:sessionDurationBucket!=3',
+            'ga:networkDomain!=ua.es',
+            'ga:networkDomain!=amazonaws.com',
+            'ga:networkDomain!=kcura.com',
+            'ga:networkDomain!=relativity.com',
+        ]
         # list of queries to send to analytics
         queries = [{
             'type': 'package',
@@ -173,7 +185,7 @@ class GACommand(p.toolkit.CkanCommand):
         }, {
             'type': 'visitorlocation',
             'dates': self.get_dates_between_update(given_start_date, AudienceLocationDate.get_latest_update_date()),
-            'filters': None,
+            'filters': ";".join(botFilters),
             'metrics': 'ga:sessions',
             'sort': '-ga:sessions',
             'dimensions': 'ga:country, ga:date',

--- a/ckanext/googleanalytics/reports.py
+++ b/ckanext/googleanalytics/reports.py
@@ -79,7 +79,7 @@ def google_analytics_location_report():
 googleanalytics_location_report_info = {
     'name': 'google-analytics-location',
     'title': 'Audience locations',
-    'description': 'Google analytics showing most audience locations',
+    'description': 'Google analytics showing most audience locations (bot traffic is filtered out)',
     'option_defaults': None,
     'option_combinations': None,
     'generate': google_analytics_location_report,


### PR DESCRIPTION
## Changes
- added filters to limit bot traffic
- hide browsers that contain = Python or StatusCake
- hide items with session duration = 0, 1, 2 or 3 seconds
- hide traffic coming from domains = ua.es, amazonaws.com, kcura.com, relativity.com