### PR TITLE
AV-579 Most popular organizations report

### DIFF
--- a/ckanext/googleanalytics/commands.py
+++ b/ckanext/googleanalytics/commands.py
@@ -93,8 +93,8 @@ class GACommand(p.toolkit.CkanCommand):
         try:
             self.service = init_service(credentialsfile)
         except TypeError:
-            print ('Have you correctly run the init service task and '
-                   'specified the correct file here')
+            print('Have you correctly run the init service task and '
+                  'specified the correct file here')
             raise Exception('Unable to create a service')
 
         return self.service
@@ -270,7 +270,7 @@ class GACommand(p.toolkit.CkanCommand):
             if not item:
                 self.log.warning("Couldn't find package %s" % package_id_or_name)
                 continue
-            
+
             for date, value in date_collection.iteritems():
                 PackageStats.update_visits(item.id, date, value["visits"], value["entrances"])
 
@@ -291,7 +291,7 @@ class GACommand(p.toolkit.CkanCommand):
             if not package:
                 self.log.warning("Couldn't find package %s" % package_id_or_name)
                 continue
-            
+
             for date, value in date_collection.iteritems():
                 PackageStats.update_downloads(package_id=package.id, visit_date=date, downloads=value["downloads"])
 
@@ -313,7 +313,7 @@ class GACommand(p.toolkit.CkanCommand):
             for result in results.get('rows'):
                 path = result[0]
                 visit_date = datetime.datetime.strptime(result[1], "%Y%m%d").date()
-                
+
                 splitPath = path.split('/')
                 path_with_vars = splitPath[splitPath.index('dataset') + 1]
                 package_id_or_name = path_with_vars.split('?')[0].split('&')[0]
@@ -324,10 +324,10 @@ class GACommand(p.toolkit.CkanCommand):
                 # add package_id_or_name if not already there
                 if package_id_or_name not in data:
                     data.setdefault(package_id_or_name, {})
-                
+
                 if visit_date not in data[package_id_or_name]:
                     data[package_id_or_name].setdefault(visit_date, {"visits": 0, "entrances": 0})
-                
+
                 # Adds visits in different languages together
                 data[package_id_or_name][visit_date]['visits'] += int(visit_count)
                 data[package_id_or_name][visit_date]['entrances'] += int(entrance_count)
@@ -345,7 +345,7 @@ class GACommand(p.toolkit.CkanCommand):
             for result in results.get('rows'):
                 path = result[0]
                 visit_date = datetime.datetime.strptime(result[1], "%Y%m%d").date()
-                
+
                 splitPath = path.split('/')
                 resource_id = splitPath[splitPath.index('resource') + 1]
 
@@ -354,10 +354,10 @@ class GACommand(p.toolkit.CkanCommand):
                 # add resource_id if not already there
                 if resource_id not in data:
                     data.setdefault(resource_id, {})
-                
+
                 if visit_date not in data[resource_id]:
-                    data[resource_id].setdefault(visit_date, { "downloads": 0 })
-                
+                    data[resource_id].setdefault(visit_date, {"downloads": 0})
+
                 # Adds downloads in different languages together
                 data[resource_id][visit_date]['downloads'] += int(download_count)
 
@@ -383,16 +383,16 @@ class GACommand(p.toolkit.CkanCommand):
                 # add package if not already there
                 if package_name not in data:
                     data.setdefault(package_name, {})
-                
+
                 # add visit_date if not already there
                 if visit_date not in data[package_name]:
                     data[package_name].setdefault(visit_date, {"downloads": 0})
-                
-                # Set total downloads to 
+
+                # Set total downloads to
                 data[package_name][visit_date]['downloads'] += int(downloads)
-        
+
         return data
-                    
+
     def resolver_type_visitorlocation(self, results, data):
         '''
         formats results and returns a dictionary like:
@@ -418,5 +418,4 @@ class GACommand(p.toolkit.CkanCommand):
         last_month_start = last_month_end.replace(day=1)
         stats = PackageStats.get_total_visits(last_month_start, last_month_end, limit=20)
         for stat in stats:
-            print (stat['entrances'], stat['package_name'], stat['visits'])
-        
+            print(stat['entrances'], stat['package_name'], stat['visits'])

--- a/ckanext/googleanalytics/model.py
+++ b/ckanext/googleanalytics/model.py
@@ -45,7 +45,8 @@ class PackageStats(Base):
         '''
         package = model.Session.query(cls).filter(cls.package_id == item_id).filter(cls.visit_date == visit_date).first()
         if package is None:
-            package = PackageStats(package_id=item_id, visit_date=visit_date, visits=visits, entrances=entrances, downloads=downloads)
+            package = PackageStats(package_id=item_id, visit_date=visit_date,
+                                   visits=visits, entrances=entrances, downloads=downloads)
             model.Session.add(package)
         else:
             if visits != 0:
@@ -68,7 +69,7 @@ class PackageStats(Base):
             cls.update_visits(item_id=package_id, visit_date=visit_date, visits=0, entrances=0, downloads=downloads)
         else:
             package.downloads += downloads
-        
+
         log.debug("Downloads updated for date: %s and packag: %s", visit_date, package_id)
         model.Session.flush()
         return True
@@ -80,7 +81,7 @@ class PackageStats(Base):
         if package is not None:
             pack_name = package.title or package.name
         return pack_name
-            
+
     @classmethod
     def get_visits(cls, start_date, end_date):
         '''
@@ -98,7 +99,7 @@ class PackageStats(Base):
         return cls.convert_to_dict(package_visits, None)
 
     @classmethod
-    def get_total_visits(cls, start_date, end_date, limit = 50, descending=True):
+    def get_total_visits(cls, start_date, end_date, limit=50, descending=True):
         '''
         Returns datasets and their visitors amount summed during time span, grouped by dataset.
 
@@ -111,13 +112,13 @@ class PackageStats(Base):
                 return desc(value)
             else:
                 return value
-            
+
         visits_by_dataset = model.Session.query(
-                cls.package_id,
-                func.sum(cls.visits).label('total_visits'),
-                func.sum(cls.downloads).label('total_downloads'),
-                func.sum(cls.entrances).label('total_entrances')
-            ) \
+            cls.package_id,
+            func.sum(cls.visits).label('total_visits'),
+            func.sum(cls.downloads).label('total_downloads'),
+            func.sum(cls.entrances).label('total_entrances')
+        ) \
             .filter(cls.visit_date >= start_date) \
             .filter(cls.visit_date <= end_date) \
             .group_by(cls.package_id) \
@@ -134,7 +135,7 @@ class PackageStats(Base):
                 "entrances": dataset.total_entrances,
                 "downloads": dataset.total_downloads,
             })
-    
+
         return datasets
 
     @classmethod
@@ -190,7 +191,8 @@ class PackageStats(Base):
 
                 last_date = model.Session.query(func.max(cls.visit_date)).filter(cls.package_id == package_id).first()
 
-                ps = PackageStats(package_id=package_id, visit_date=last_date[0], visits=visits, entrances=package[2], downloads=package[3])
+                ps = PackageStats(package_id=package_id,
+                                  visit_date=last_date[0], visits=visits, entrances=package[2], downloads=package[3])
                 package_stats.append(ps)
         dictat = PackageStats.convert_to_dict(package_stats, None)
         return dictat
@@ -283,7 +285,6 @@ class PackageStats(Base):
         response = requests.get(url)
         return response.json()['result']['organization']['name']
 
-
     @classmethod
     def get_organizations_with_most_popular_datasets(cls, start_date, end_date, limit=20):
         all_packages_result = cls.get_total_visits(start_date, end_date, limit=None)
@@ -313,7 +314,7 @@ class PackageStats(Base):
                  "total_visits": stats["visits"],
                  "total_downloads": stats["downloads"],
                  "total_entrances": stats["entrances"]
-                }
+                 }
             )
 
         return sorted(organization_list, key=lambda organization: organization["total_visits"], reverse=True)[:limit]
@@ -512,6 +513,7 @@ class ResourceStats(Base):
         else:
             return result.visit_date
 
+
 class AudienceLocation(Base):
     """
     Contains stats for different visitors locations
@@ -521,7 +523,7 @@ class AudienceLocation(Base):
 
     id = Column(types.Integer, primary_key=True, autoincrement=True, unique=True)
     location_name = Column(types.UnicodeText, nullable=False, primary_key=True)
-    
+
     visits_by_date = relationship("AudienceLocationDate", back_populates="location")
 
     @classmethod

--- a/ckanext/googleanalytics/model.py
+++ b/ckanext/googleanalytics/model.py
@@ -790,6 +790,5 @@ def maybe_negate(value, inputvalue, negate=False):
 
 
 def init_tables(engine):
-    Base.metadata.drop_all(engine)
     Base.metadata.create_all(engine)
     log.info('Google analytics database tables are set-up')

--- a/ckanext/googleanalytics/model.py
+++ b/ckanext/googleanalytics/model.py
@@ -283,7 +283,10 @@ class PackageStats(Base):
     def get_organization(cls, dataset_name):
         url = config.get("ckan.site_url") + "/data/api/3/action/package_show?id=" + dataset_name
         response = requests.get(url)
-        return response.json()['result']['organization']['name']
+        if response:
+            return response.json()['result']['organization']['name']
+        else:
+            response.raise_for_status()
 
     @classmethod
     def get_organizations_with_most_popular_datasets(cls, start_date, end_date, limit=20):

--- a/ckanext/googleanalytics/model.py
+++ b/ckanext/googleanalytics/model.py
@@ -287,7 +287,7 @@ class PackageStats(Base):
     @classmethod
     def get_organizations_with_most_popular_datasets(cls, start_date, end_date, limit=20):
         all_packages_result = cls.get_total_visits(start_date, end_date, limit=None)
-        organization_stats = {}  # Map organization name to total visit count
+        organization_stats = {}
         for package in all_packages_result:
             package_id = package["package_id"]
             visits = package["visits"]

--- a/ckanext/googleanalytics/model.py
+++ b/ckanext/googleanalytics/model.py
@@ -176,8 +176,13 @@ class PackageStats(Base):
     def get_top(cls, limit=20):
         package_stats = []
         # TODO: Reimplement in more efficient manner if needed (using RANK OVER and PARTITION in raw sql)
-        unique_packages = model.Session.query(cls.package_id, func.count(cls.visits), func.count(cls.entrances), func.count(cls.downloads)).group_by(cls.package_id).order_by(
-            func.count(cls.visits).desc()).limit(limit).all()
+        unique_packages = (model.Session.query(cls.package_id,
+                                               func.count(cls.visits),
+                                               func.count(cls.entrances),
+                                               func.count(cls.downloads))
+                                        .group_by(cls.package_id)
+                                        .order_by(func.count(cls.visits).desc())
+                                        .limit(limit).all())
         # Adding last date associated to this package stat and filtering out private and deleted packages
         if unique_packages is not None:
             for package in unique_packages:

--- a/ckanext/googleanalytics/plugin.py
+++ b/ckanext/googleanalytics/plugin.py
@@ -167,4 +167,5 @@ class GoogleAnalyticsPlugin(p.SingletonPlugin, DefaultTranslation):
         """Register details of an extension's reports"""
         import reports
         return [reports.googleanalytics_dataset_report_info, reports.googleanalytics_resource_report_info,
-                reports.googleanalytics_location_report_info, reports.googleanalytics_dataset_least_popular_report_info]
+                reports.googleanalytics_location_report_info, reports.googleanalytics_dataset_least_popular_report_info,
+                reports.googleanalytics_organizations_with_most_popular_datasets_info]

--- a/ckanext/googleanalytics/reports.py
+++ b/ckanext/googleanalytics/reports.py
@@ -43,7 +43,7 @@ def google_analytics_dataset_report(time):
     start_date, end_date = last_calendar_period(time)
 
     # get package objects corresponding to popular GA content
-    top_packages = PackageStats.get_total_visits(start_date=start_date, end_date=end_date, limit=0)
+    top_packages = PackageStats.get_total_visits(start_date=start_date, end_date=end_date, limit=None)
     top_20 = top_packages[:20]
 
     return {
@@ -77,7 +77,7 @@ def google_analytics_dataset_least_popular_report(time):
     start_date, end_date = last_calendar_period(time)
 
     # get package objects corresponding to popular GA content
-    top_packages = PackageStats.get_total_visits(start_date=start_date, end_date=end_date, limit=0, descending=False)
+    top_packages = PackageStats.get_total_visits(start_date=start_date, end_date=end_date, limit=None, descending=False)
     top_20 = top_packages[:20]
 
     return {

--- a/ckanext/googleanalytics/reports.py
+++ b/ckanext/googleanalytics/reports.py
@@ -34,6 +34,7 @@ def last_calendar_period(period):
     else:
         raise ValueError("The period parameter should be either 'week', 'month' or 'year'")
 
+
 def google_analytics_dataset_report(time):
     '''
     Generates report based on google analytics data. number of views per package
@@ -44,7 +45,6 @@ def google_analytics_dataset_report(time):
     # get package objects corresponding to popular GA content
     top_packages = PackageStats.get_total_visits(start_date=start_date, end_date=end_date, limit=0)
     top_20 = top_packages[:20]
-
 
     return {
         'table': top_packages,
@@ -67,6 +67,7 @@ googleanalytics_dataset_report_info = {
     'generate': google_analytics_dataset_report,
     'template': 'report/dataset_analytics.html',
 }
+
 
 def google_analytics_dataset_least_popular_report(time):
     '''

--- a/ckanext/googleanalytics/reports.py
+++ b/ckanext/googleanalytics/reports.py
@@ -157,3 +157,21 @@ googleanalytics_location_report_info = {
     'generate': google_analytics_location_report,
     'template': 'report/location_analytics.html'
 }
+
+
+def google_analytics_organizations_with_most_popular_datasets(time):
+    most_popular_organizations = PackageStats.get_organizations_with_most_popular_datasets(time)
+    return {
+        'table': most_popular_organizations
+    }
+
+
+googleanalytics_organizations_with_most_popular_datasets_info = {
+    'name': 'google-analytics-most-popular-organizations',
+    'title': 'Most popular organizations',
+    'description': 'Google analytics showing most popular organizations by visited datasets',
+    'option_defaults': OrderedDict((('time', 'month'),)),
+    'option_combinations': google_analytics_dataset_option_combinations,
+    'generate': google_analytics_organizations_with_most_popular_datasets,
+    'template': 'report/organization_analytics.html'
+}

--- a/ckanext/googleanalytics/reports.py
+++ b/ckanext/googleanalytics/reports.py
@@ -3,22 +3,21 @@ from ckanext.googleanalytics.model import PackageStats, ResourceStats, AudienceL
 from datetime import datetime, timedelta
 
 
-def last_calendar_week():
+def last_week():
     today = datetime.today()
-    start_date = today - timedelta(days=today.weekday(), weeks=1)
-    end_date = today - timedelta(days=today.weekday() + 1)
+    end_date = today - timedelta(days=1)
+    start_date = end_date - timedelta(days=7)
     return start_date, end_date
 
 
-def last_calendar_month():
+def last_month():
     today = datetime.today()
-    end_date = today.replace(day=1) - timedelta(days=1)
-    start_date = end_date.replace(day=1)
+    end_date = today - timedelta(days=1)
+    start_date = end_date - timedelta(days=30)
     return start_date, end_date
 
-#  TODO: Currently, this doesn't actually return the last calendar year, should it?
-#        But if it would, then there would be no option available to check the latest data
-def last_calendar_year():
+
+def last_year():
     today = datetime.today()
     end_date = today - timedelta(days=1)
     start_date = end_date - timedelta(days=365)
@@ -27,11 +26,11 @@ def last_calendar_year():
 
 def last_calendar_period(period):
     if period == 'week':
-        return last_calendar_week()
+        return last_week()
     elif period == 'month':
-        return last_calendar_month()
+        return last_month()
     elif period == 'year':
-        return last_calendar_year()
+        return last_year()
     else:
         raise ValueError("The period parameter should be either 'week', 'month' or 'year'")
 

--- a/ckanext/googleanalytics/templates/report/dataset_analytics.html
+++ b/ckanext/googleanalytics/templates/report/dataset_analytics.html
@@ -14,19 +14,7 @@
           <td>{{ h.link_to(toppackage.package_name, h.url_for(controller='package', action='read', id=toppackage.package_id)) }}</td>
           <td>{{ toppackage.visits }}</td>
           <td>{{ toppackage.entrances }}</td>
-          {% set percent = 0 %}
-          {% if toppackage.visits != 0 %}{% set percent = ((toppackage.entrances / toppackage.visits) * 100)|round(1, 'floor') %}{% endif %}
-          {% set percent_class = 'color_danger' %}
-          {% if percent > 25 %}
-            {% set percent_class = 'color_warning' %}
-              {% if percent > 50 %}
-                {% set percent_class = 'color_info' %}
-                {% if percent > 75 %}
-                  {% set percent_class = 'color_success' %}
-                {% endif %}
-              {% endif %}
-          {% endif %}
-          <td class="{{ percent_class }}">{{ percent }}%</td>
+          {% snippet "report/snippets/entrances_percentage_td.html", toppackage=toppackage %}
           <td>{{ toppackage.downloads }}</td>
         </tr>
       {% endfor %}

--- a/ckanext/googleanalytics/templates/report/dataset_analytics.html
+++ b/ckanext/googleanalytics/templates/report/dataset_analytics.html
@@ -14,7 +14,7 @@
           <td>{{ h.link_to(toppackage.package_name, h.url_for(controller='package', action='read', id=toppackage.package_id)) }}</td>
           <td>{{ toppackage.visits }}</td>
           <td>{{ toppackage.entrances }}</td>
-          {% snippet "report/snippets/entrances_percentage_td.html", toppackage=toppackage %}
+          {% snippet "report/snippets/entrances_percentage_td.html", total_visits=toppackage.visits, total_entrances=toppackage.entrances %}
           <td>{{ toppackage.downloads }}</td>
         </tr>
       {% endfor %}

--- a/ckanext/googleanalytics/templates/report/organization_analytics.html
+++ b/ckanext/googleanalytics/templates/report/organization_analytics.html
@@ -3,7 +3,7 @@
     {% if data['table'] %}
       <table class="table table-condensed table-bordered table-striped">
       <tr>
-        <th>{% trans %}Dataset{% endtrans %}</th>
+        <th>{% trans %}Organization{% endtrans %}</th>
         <th>{% trans %}Total views{% endtrans %}</th>
         <th>{% trans %}Initial entrance{% endtrans %}</th>
         <th>{% trans %}Entrances of total views{% endtrans %}</th>

--- a/ckanext/googleanalytics/templates/report/organization_analytics.html
+++ b/ckanext/googleanalytics/templates/report/organization_analytics.html
@@ -1,0 +1,20 @@
+<div class="module-content">
+  <h2>{% trans %}Organizations with most viewed datasets{% endtrans %}</h2> 
+    {% if data['table'] %}
+      <table class="table table-condensed table-bordered table-striped">
+      <tr>
+        <th>{% trans %}Organization{% endtrans %}</th>
+        <th>{% trans %}Number of total dataset views (since recording started){% endtrans %}</th>
+      </tr>
+        {% for toppackage in table %}
+          <tr>
+            <td>{{ h.link_to(toppackage.organization_name, h.url_for(controller='organization', action='read', id=toppackage.organization_name)) }}</td>
+            <td>{{ toppackage.total_visits }}</td>
+          </tr>
+        {% endfor %}
+      </table>
+    {% else %}
+      <p>{% trans %}No analytics found for organizations with most visited datasets.{% endtrans %}</p>
+    {% endif %}
+
+ </div>

--- a/ckanext/googleanalytics/templates/report/organization_analytics.html
+++ b/ckanext/googleanalytics/templates/report/organization_analytics.html
@@ -14,7 +14,7 @@
             <td>{{ h.link_to(toppackage.organization_name, h.url_for(controller='organization', action='read', id=toppackage.organization_name)) }}</td>
             <td>{{ toppackage.total_visits }}</td>
             <td>{{ toppackage.total_entrances }}</td>
-            {% snippet "report/snippets/entrances_percentage_td.html", toppackage=toppackage %}
+            {% snippet "report/snippets/entrances_percentage_td.html", total_visits=toppackage.total_visits, total_entrances=toppackage.total_entrances %}
             <td>{{ toppackage.total_downloads }}</td>
           </tr>
         {% endfor %}

--- a/ckanext/googleanalytics/templates/report/organization_analytics.html
+++ b/ckanext/googleanalytics/templates/report/organization_analytics.html
@@ -3,13 +3,32 @@
     {% if data['table'] %}
       <table class="table table-condensed table-bordered table-striped">
       <tr>
-        <th>{% trans %}Organization{% endtrans %}</th>
-        <th>{% trans %}Number of total dataset views (since recording started){% endtrans %}</th>
+        <th>{% trans %}Dataset{% endtrans %}</th>
+        <th>{% trans %}Total views{% endtrans %}</th>
+        <th>{% trans %}Initial entrance{% endtrans %}</th>
+        <th>{% trans %}Entrances of total views{% endtrans %}</th>
+        <th>{% trans %}Downloads{% endtrans %}</th>
       </tr>
         {% for toppackage in table %}
           <tr>
             <td>{{ h.link_to(toppackage.organization_name, h.url_for(controller='organization', action='read', id=toppackage.organization_name)) }}</td>
             <td>{{ toppackage.total_visits }}</td>
+            <td>{{ toppackage.total_downloads }}</td>
+            <td>{{ toppackage.total_entrances }}</td>
+            
+            {% set percent = 0 %}
+            {% if toppackage.visits != 0 %}{% set percent = ((toppackage.total_entrances / toppackage.total_visits) * 100)|round(1, 'floor') %}{% endif %}
+            {% set percent_class = 'color_danger' %}
+            {% if percent > 25 %}
+              {% set percent_class = 'color_warning' %}
+                {% if percent > 50 %}
+                  {% set percent_class = 'color_info' %}
+                  {% if percent > 75 %}
+                    {% set percent_class = 'color_success' %}
+                  {% endif %}
+                {% endif %}
+            {% endif %}
+            <td class="{{ percent_class }}">{{ percent }}%</td>
           </tr>
         {% endfor %}
       </table>

--- a/ckanext/googleanalytics/templates/report/organization_analytics.html
+++ b/ckanext/googleanalytics/templates/report/organization_analytics.html
@@ -13,22 +13,9 @@
           <tr>
             <td>{{ h.link_to(toppackage.organization_name, h.url_for(controller='organization', action='read', id=toppackage.organization_name)) }}</td>
             <td>{{ toppackage.total_visits }}</td>
-            <td>{{ toppackage.total_downloads }}</td>
             <td>{{ toppackage.total_entrances }}</td>
-            
-            {% set percent = 0 %}
-            {% if toppackage.visits != 0 %}{% set percent = ((toppackage.total_entrances / toppackage.total_visits) * 100)|round(1, 'floor') %}{% endif %}
-            {% set percent_class = 'color_danger' %}
-            {% if percent > 25 %}
-              {% set percent_class = 'color_warning' %}
-                {% if percent > 50 %}
-                  {% set percent_class = 'color_info' %}
-                  {% if percent > 75 %}
-                    {% set percent_class = 'color_success' %}
-                  {% endif %}
-                {% endif %}
-            {% endif %}
-            <td class="{{ percent_class }}">{{ percent }}%</td>
+            {% snippet "report/snippets/entrances_percentage_td.html", toppackage=toppackage %}
+            <td>{{ toppackage.total_downloads }}</td>
           </tr>
         {% endfor %}
       </table>

--- a/ckanext/googleanalytics/templates/report/snippets/entrances_percentage_td.html
+++ b/ckanext/googleanalytics/templates/report/snippets/entrances_percentage_td.html
@@ -1,0 +1,13 @@
+{% set percent = 0 %}
+{% if toppackage.visits != 0 %}{% set percent = ((toppackage.total_entrances / toppackage.total_visits) * 100)|round(1, 'floor') %}{% endif %}
+{% set percent_class = 'color_danger' %}
+{% if percent > 25 %}
+  {% set percent_class = 'color_warning' %}
+    {% if percent > 50 %}
+      {% set percent_class = 'color_info' %}
+      {% if percent > 75 %}
+        {% set percent_class = 'color_success' %}
+      {% endif %}
+    {% endif %}
+{% endif %}
+<td class="{{ percent_class }}">{{ percent }}%</td>

--- a/ckanext/googleanalytics/templates/report/snippets/entrances_percentage_td.html
+++ b/ckanext/googleanalytics/templates/report/snippets/entrances_percentage_td.html
@@ -1,5 +1,5 @@
 {% set percent = 0 %}
-{% if toppackage.visits != 0 %}{% set percent = ((toppackage.total_entrances / toppackage.total_visits) * 100)|round(1, 'floor') %}{% endif %}
+{% if total_visits != 0 %}{% set percent = ((total_entrances / total_visits) * 100)|round(1, 'floor') %}{% endif %}
 {% set percent_class = 'color_danger' %}
 {% if percent > 25 %}
   {% set percent_class = 'color_warning' %}


### PR DESCRIPTION
  - A new report, which shows most popular organizations based on the amount of total visits their datasets have. The table also shows total number of downloads, entrances and percentage of entrances. 

  - Changed time options to be for last 7 days, last 30 days and last year

  - Move percentage of entrances calculation into a separate snipper

  - Flake8 style changes